### PR TITLE
Remove resources lib from module import - make conditional per OS

### DIFF
--- a/stressinjector/memory.py
+++ b/stressinjector/memory.py
@@ -1,6 +1,5 @@
 import logging
 import math
-import resource
 import time
 from typing import Union
 
@@ -106,10 +105,13 @@ class MemoryStress:
                 `memory_info <https://psutil.readthedocs.io/en/latest/#psutil.Process.memory_info>`__
         """
         if settings.os == operating_system.macOS:
+            import resource
             return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         if settings.os == operating_system.linux:
+            import resource
             return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1e+3
         if settings.os == operating_system.windows:
+            import psutil
             return psutil.Process(settings.pid).memory_info().peak_wset
 
     def _run(self) -> None:


### PR DESCRIPTION
As per https://stackoverflow.com/questions/49232580/how-to-import-resource-module, Python lib resource is not available for Windows systems (only for Unix based systems). You covered that in the conditional use of resource vs psutil, but resource is still generally imported in the module, leading to an ImportError in Windows OS.